### PR TITLE
Fix/url search param

### DIFF
--- a/.changeset/giant-mails-fry.md
+++ b/.changeset/giant-mails-fry.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-rest": patch
+---
+
+Fix URLSearchParam not available in browser issue

--- a/src/RequestBuilder.ts
+++ b/src/RequestBuilder.ts
@@ -1,4 +1,3 @@
-import {URLSearchParams} from "node:url";
 import {RestRequestRetriever} from "@dota/RequestRetriever.ts";
 import {Header, HttpMethod, RequestSetup, ResponseHandler} from "@dota/Types.ts";
 import {ResponseResolver} from "@dota/ResponseResolver.ts";


### PR DESCRIPTION
This pull request includes a fix for an issue where `URLSearchParams` was not available in the browser, and updates the package version accordingly.

Fixes and updates:

* [`.changeset/giant-mails-fry.md`](diffhunk://#diff-b62b004f7cb754134439ac012becec3dfe80780b28ac30a03d8bb7d3c06b89baR1-R5): Added a changeset entry to document the patch for the `@ayu-sh-kr/dota-rest` package.
* [`src/RequestBuilder.ts`](diffhunk://#diff-892a5e87fb23f820aa8f5b054e73f2c9190677e28dc19434aa5dfcea9a71547eL1): Removed the import of `URLSearchParams` from the `node:url` module to address the browser compatibility issue.